### PR TITLE
Events are passed as json string, deserialize first

### DIFF
--- a/lib/sensu/extensions/deregistration.rb
+++ b/lib/sensu/extensions/deregistration.rb
@@ -51,6 +51,7 @@ module Sensu
 
       def run(event, &callback)
         handle = proc do
+          event = Sensu::JSON.load(event)
           client_name = event[:client][:name]
           begin
             Timeout.timeout(options[:timeout]) do

--- a/spec/deregistration_spec.rb
+++ b/spec/deregistration_spec.rb
@@ -20,7 +20,7 @@ describe 'Sensu::Extension::Deregistration' do
 
     it 'can delete a client' do
       async_wrapper do
-        @extension.safe_run(event_template) do |output, status|
+        @extension.safe_run(Sensu::JSON.dump(event_template)) do |output, status|
           puts output.inspect
           expect(output).to eq("deleted client #{client_template[:name]}")
           expect(status).to eq(0)
@@ -39,7 +39,7 @@ describe 'Sensu::Extension::Deregistration' do
     end
     it 'can delete a client' do
       async_wrapper do
-        @extension.safe_run(event_template) do |output, status|
+        @extension.safe_run(Sensu::JSON.dump(event_template)) do |output, status|
           puts output.inspect
           expect(output).to eq("deleted client #{client_template[:name]}")
           expect(status).to eq(0)
@@ -60,7 +60,7 @@ describe 'Sensu::Extension::Deregistration' do
     end
     it 'can delete a client' do
       async_wrapper do
-        @extension.safe_run(event_template) do |output, status|
+        @extension.safe_run(Sensu::JSON.dump(event_template)) do |output, status|
           puts output.inspect
           expect(output).to eq("deleted client #{client_template[:name]}")
           expect(status).to eq(0)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

The event data sent to extension handlers is actually a JSON string. The event should be deserialized before we try to interact with it like a ruby hash.